### PR TITLE
tweak of oatmeal

### DIFF
--- a/oatmeal.py
+++ b/oatmeal.py
@@ -42,7 +42,7 @@ from rich.theme import Theme
 
 __version__ = '0.1'
 
-QUTE_PATH = '/home/archx/.local/share/qutebrowser/webengine'
+QUTE_PATH = '~/.local/share/qutebrowser/webengine'
 DB_PATH = QUTE_PATH + '/Cookies'
 WL_PATH = QUTE_PATH + '/whitelist.json'
 BL_PATH = QUTE_PATH + '/blacklist.json'


### PR DESCRIPTION
Hi,

This small hack of oatmeal.py add some usefull changes:
 - sch, swh, swh can now select multiples hostnames
 - Four commands are new:
   aw : add the selection (sch) to whitelist
   ab : add the selection (sch) to blacklist
   rw : remove the selection (swh) from whitelist
   rb : remove the selection (sbh) from blacklist